### PR TITLE
ドメインモデルへの変換

### DIFF
--- a/composables/pokemons/index.ts
+++ b/composables/pokemons/index.ts
@@ -12,7 +12,7 @@ export const usePokemons = async (query: Query = {}) => {
 		default: () => [],
 		transform: (response) => {
 			if (!response) return [];
-			return response.results;
+			return response;
 		},
 	});
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,10 +8,16 @@ const { pokemons } = await usePokemons();
 	<div>
 		<h1 class="text-2xl font-bold">PokeDex</h1>
 
-		<ul>
+		<ul class="grid grid-cols-[repeat(auto-fill,_minmax(120px,_1fr))] gap-4">
 			<li v-for="pokemon in pokemons" :key="pokemon.name">
 				<NuxtLink :to="`/pokemons/${pokemon.name}`">
-					{{ pokemon.name }}
+					<img :src="pokemon.image" alt="" width="120" height="120" />
+					<p>id: {{ pokemon.id }}</p>
+					<p>name: {{ pokemon.name }}</p>
+					<p class="space-x-1">
+						types:
+						<span v-for="type in pokemon.types" :key="type">{{ type }}</span>
+					</p>
 				</NuxtLink>
 			</li>
 		</ul>

--- a/pages/pokemons/[name]/index.vue
+++ b/pages/pokemons/[name]/index.vue
@@ -13,28 +13,23 @@ const { pokemon } = await usePokemon(route.params.name as string);
 			<p>name: {{ pokemon.name }}</p>
 			<p>height: {{ pokemon.height }}</p>
 			<p>weight: {{ pokemon.weight }}</p>
-			<img
-				:src="pokemon.sprites.front_default"
-				alt=""
-				width="120"
-				height="120"
-			/>
+			<img :src="pokemon.image" alt="" width="120" height="120" />
 			<p class="space-x-2">
 				types:
 				<span v-for="(type, index) in pokemon.types" :key="index">{{
-					type.type.name
+					type
 				}}</span>
 			</p>
 			<p class="space-x-2">
 				abilities:
 				<span v-for="(ability, index) in pokemon.abilities" :key="index">{{
-					ability.ability.name
+					ability
 				}}</span>
 			</p>
 			<p class="space-x-2">
 				stats:
 				<span v-for="(stat, index) in pokemon.stats" :key="index">
-					{{ stat.stat.name }}{{ stat.base_stat }}
+					{{ stat.name }}{{ stat.value }}
 				</span>
 			</p>
 		</div>

--- a/server/api/v1/pokemons/index.get.ts
+++ b/server/api/v1/pokemons/index.get.ts
@@ -20,6 +20,7 @@ export default defineCachedEventHandler(
 		}
 	},
 	{
+		swr: false,
 		// maxAgeオプション: キャッシュの有効期限を設定 (1日)
 		// 24 * 60 * 60 = 86400秒 = 1日
 		maxAge: 24 * 60 * 60,

--- a/server/domains/models/pokemons/index.ts
+++ b/server/domains/models/pokemons/index.ts
@@ -1,4 +1,16 @@
 import z from 'zod';
+import type { Pokemon as PokemonFromPokeApi } from '~/server/infrastructures/pokeapi';
+
+// ポケモン一覧ドメインモデルのスキーマ
+const pokemonsSchema = z.object({
+	id: z.number(),
+	name: z.string(),
+	image: z.string(),
+	types: z.string().array(),
+});
+
+// スキーマから型を取り出す
+export type Pokemons = z.infer<typeof pokemonsSchema>;
 
 // クエリのスキーマ
 const querySchema = z
@@ -14,4 +26,14 @@ export type PokemonsQuery = z.infer<typeof querySchema>;
 // クエリのバリデーション
 export const validatePokemonsQuery = (query: unknown): PokemonsQuery => {
 	return querySchema.parse(query);
+};
+
+// PokeAPIから受け取ったデータをポケモン一覧ドメインモデルへ変換
+export const convert = (pokemon: PokemonFromPokeApi): Pokemons => {
+	return pokemonsSchema.parse({
+		id: pokemon.id,
+		name: pokemon.name,
+		image: pokemon.sprites.front_default,
+		types: pokemon.types.map((type) => type.type.name),
+	});
 };

--- a/server/domains/models/pokemons/pokemon.ts
+++ b/server/domains/models/pokemons/pokemon.ts
@@ -1,4 +1,26 @@
 import z from 'zod';
+// インフラからPokeAPIの詳細の型をインポート
+import type { Pokemon as PokemonFromPokeApi } from '~/server/infrastructures/pokeapi';
+
+// ポケモン詳細ドメインモデルのスキーマ
+const pokemonSchema = z.object({
+	id: z.number(),
+	name: z.string(),
+	height: z.string(),
+	weight: z.string(),
+	abilities: z.string().array(),
+	image: z.string(),
+	stats: z
+		.object({
+			name: z.string(),
+			value: z.number(),
+		})
+		.array(),
+	types: z.string().array(),
+});
+
+// スキーマから型を取り出す
+export type Pokemon = z.infer<typeof pokemonSchema>;
 
 // routerParamsのスキーマ
 const routerParamsSchema = z.object({
@@ -12,4 +34,55 @@ export type PokemonParams = z.infer<typeof routerParamsSchema>;
 // 任意のデータ（unknown型）を引数に取り、parseメソッドでバリデーションを実行。
 export const validatePokemonParams = (routerParams: unknown): PokemonParams => {
 	return routerParamsSchema.parse(routerParams);
+};
+
+// PokeAPIから受け取ったデータをポケモン詳細ドメインモデルへ変換
+export const convert = (pokemon: PokemonFromPokeApi): Pokemon => {
+	return pokemonSchema.parse({
+		id: pokemon.id,
+		name: pokemon.name,
+		height: convertHeight(pokemon.height),
+		weight: convertWeight(pokemon.weight),
+		abilities: pokemon.abilities.map((ability) => ability.ability.name),
+		image: pokemon.sprites.front_default,
+		stats: calculateStats(pokemon.stats),
+		types: pokemon.types.map((type) => type.type.name),
+	});
+};
+
+// 高さをドメインモデル(メートル)に変換
+const convertHeight = (height: number): string => {
+	return (height / 10).toString() + 'm';
+};
+
+// 重さをドメインモデル(キログラム)に変換
+const convertWeight = (weight: number): string => {
+	return (weight / 10).toString() + 'kg';
+};
+
+// ステータスに合計値を計算し含める
+const calculateStats = (
+	pokemonStats: PokemonFromPokeApi['stats']
+): { name: string; value: number }[] => {
+	// ステータス名マッピング用
+	const statNameMapping: Record<string, string> = {
+		hp: 'HP',
+		attack: 'こうげき',
+		defense: 'ぼうぎょ',
+		'special-attack': 'とくこう',
+		'special-defense': 'とくぼう',
+		speed: 'すばやさ',
+	};
+
+	// ステータスをドメインモデルへ変換
+	const stats = pokemonStats.map((stat) => ({
+		name: statNameMapping[stat.stat.name] || stat.stat.name,
+		value: stat.base_stat,
+	}));
+	// 合計値を計算
+	const totalStats = stats.reduce((sum, stat) => sum + stat.value, 0);
+	// 合計値をステータスに追加
+	stats.push({ name: '合計', value: totalStats });
+
+	return stats;
 };

--- a/server/domains/repositories/pokemons/index.ts
+++ b/server/domains/repositories/pokemons/index.ts
@@ -1,15 +1,19 @@
-// モデルからクエリの型をインポート
-import type { PokemonsQuery } from '~/server/domains/models/pokemons';
-// インフラからPokeAPIの一覧と詳細の型をインポート
+// モデルからクエリの型とポケモン詳細ドメインモデルの型をインポート
+import type { Pokemon } from '~/server/domains/models/pokemons/pokemon';
+// ポケモン一覧ドメインモデルの型をインポート
 import type {
-	Pokemons as PokemonsFromPokeApi,
-	Pokemon as PokemonFromPokeApi,
-} from '~/server/infrastructures/pokeapi/pokemons';
+	PokemonsQuery,
+	Pokemons as PokemonListItem,
+} from '~/server/domains/models/pokemons';
 // インフラからPokeAPIの一覧と詳細の取得処理をインポート
 import {
 	getPokemons as getPokemonsFromPokeApi,
 	getPokemon as getPokemonFromPokeApi,
 } from '~/server/infrastructures/pokeapi/pokemons';
+// ポケモン一覧ドメインモデルへの変換処理をインポート
+import { convert as convertListItem } from '~/server/domains/models/pokemons';
+// ポケモン詳細ドメインモデルへの変換処理をインポート
+import { convert } from '~/server/domains/models/pokemons/pokemon';
 
 // クエリを生成するメソッド　不必要なクエリを除外
 const createQuery = ({ offset, limit }: PokemonsQuery) => {
@@ -28,15 +32,23 @@ const createQuery = ({ offset, limit }: PokemonsQuery) => {
 // データの取得元が変更される可能性に柔軟に対応するため(PokeAPI → データベース に切り替える場合、インフラ層の処理を変更するだけで済む)
 export const getPokemons = async (
 	query: PokemonsQuery
-): Promise<PokemonsFromPokeApi> => {
-	const pokemons = await getPokemonsFromPokeApi(createQuery(query));
+): Promise<PokemonListItem[]> => {
+	const pokemonsFromPokeApi = await getPokemonsFromPokeApi(createQuery(query));
+	const pokemons = await Promise.all(
+		pokemonsFromPokeApi.results.map(async (pokemon) => {
+			//ポケモン名からポケモン詳細取得
+			const response = await getPokemonFromPokeApi(pokemon.name);
+			// ポケモン一覧どうメインモデルへ変換
+			return convertListItem(response);
+		})
+	);
 
 	return pokemons;
 };
 
 // ポケモン詳細取得処理を抽象化
-export const getPokemon = async (name: string): Promise<PokemonFromPokeApi> => {
+export const getPokemon = async (name: string): Promise<Pokemon> => {
 	const pokemon = await getPokemonFromPokeApi(name);
 
-	return pokemon;
+	return convert(pokemon);
 };


### PR DESCRIPTION
# この PR の目的

ドメインモデルへの変換

(ドメインモデルの型定義は、APIから取得した生データ（Raw Data）をアプリケーションで扱いやすいデータ構造に変換し、型安全に管理するための型定義)

# やったこと

一覧画面と詳細画面でそれぞれ表示に必要な形にする

・一覧画面
一覧 API のレスポンスだけでは必要なデータが足りないため、リポジトリ層で一部詳細データも取得するように実装します。
(~/server/domains/repositories/pokemons/index.ts)

・詳細画面
詳細APIで取得したデータを元に表示用に変換が必要なデータを変換して表示する(高さ、重さ、ステータス　etc)


